### PR TITLE
20200513-kyvenko-fix-swipe-up-down

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sergiiivzhenko-react-image-gallery",
-  "version": "0.9.10",
+  "version": "0.9.11",
   "description": "React carousel image gallery component with thumbnail and mobile support",
   "main": "./build/image-gallery.js",
   "scripts": {

--- a/src/ImageGallery.jsx
+++ b/src/ImageGallery.jsx
@@ -677,15 +677,22 @@ export default class ImageGallery extends React.Component {
       if (Math.abs(offsetPercentage) >= 100) {
         offsetPercentage = 100;
       }
+      if(Math.abs(offsetPercentage) < 15){
+        offsetPercentage = 0;
+      }
 
       const swipingTransition = {
         transition: `transform ${swipingTransitionDuration}ms ease-out`,
       };
 
-      this.setState({
-        offsetPercentage: side * offsetPercentage,
-        slideStyle: swipingTransition,
-      });
+      if(dir === "Up" || dir === "Down"  ){
+        this.setState({ offsetPercentage: 0 });
+      }else{
+        this.setState({
+          offsetPercentage: side * offsetPercentage,
+          slideStyle: swipingTransition
+        });
+      }
     } else {
       // don't move the slide
       this.setState({ offsetPercentage: 0 });


### PR DESCRIPTION
when the user swipes up and down fast, the slide is twigging from left to right. I looked at the code and found that the bug appears when the user swipes up-down quickly and sometimes it can triggers the left-right event. This behaviour comes from "react-swipeable".
https://www.youtube.com/watch?v=Q3Y3lvMXPNk
https://www.youtube.com/watch?v=B60C-pl7qug